### PR TITLE
upload the html content to S3 also

### DIFF
--- a/src/lib/upload-to-s3.js
+++ b/src/lib/upload-to-s3.js
@@ -3,10 +3,11 @@ const AWS = require('aws-sdk')
 const bucket = 'ccshutterbug'
 const s3 = new AWS.S3()
 
-module.exports = function uploadToS3 (key, buffer) {
+module.exports = function uploadToS3 (key, buffer, contentType) {
   return new Promise((resolve, reject) => {
     console.log('uploading', key, 'to S3 bucket...')
-    s3.upload({ Bucket: bucket, Key: key, Body: buffer }, function (err, data) {
+    s3.upload({ Bucket: bucket, Key: key,
+      ContentType: contentType, Body: buffer }, function (err, data) {
       if (err) {
         reject(err)
       } else {


### PR DESCRIPTION
this helps developers track down issues when snapshots do not turn out right
it shouldn't add extra time because it is async and not waited for

this also sets the content type when uploading the content which makes it
easier to view html and image files directly