### PR TITLE
Improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Shutterbug AWS Lambda 
+# Shutterbug AWS Lambda
 
 ## Production:
 https://fh1fzvhx93.execute-api.us-east-1.amazonaws.com/production/make-snapshot
@@ -13,18 +13,18 @@ https://dgjr6g3z30.execute-api.us-east-1.amazonaws.com/staging/make-snapshot
 
 ## Basic test
 
-`npm run test` will run a simple test using Chrome in a regular, non-headless mode.
+`npm run test` will run a simple test using Chrome in a regular, headless mode.
 
 ## Run local webserver
 
-- `npm run server` starts a simple web server at `localhost:4000`. Chrome will be in regular mode, with 500ms slowdown. You can point Shutterbug JavaScript library to use it.
-- `npm run server-headless` starts a simple web server at `localhost:4000`. Chrome will be in headless mode. You can point Shutterbug JavaScript library to use it.
+- `npm run server` starts a simple web server at `localhost:4000`. Chrome will be in headless mode. You can point Shutterbug JavaScript library to use it.
+- `npm run server-non-headless` starts a simple web server at `localhost:4000`. Chrome will be in non-headless mode with 500ms slowdown. You can point Shutterbug JavaScript library to use it.
 
 Check https://github.com/concord-consortium/shutterbug.js library and its demo pages for local testing.
 
 ## Packaging & Deploy
 
-### Build Lambda package.zip 
+### Build Lambda package.zip
 
 Run `npm run package`, and deploy the package.zip using AWS Lambda CLI or website.
 
@@ -46,7 +46,7 @@ AWS Lambda's memory needs to be set to at least 384 MB, but the more memory, the
 ## Update Headless-Chrome
 
 Chrome is provided by `chrome-aws-lambda` (special build for AWS Lambda env) and `puppeteer` packages (local testing).
-Each version bundles different Chrome version. It should enough to update these packages (+ `puppeteer-core`) to 
+Each version bundles different Chrome version. It should enough to update these packages (+ `puppeteer-core`) to
 use a new Chrome version.
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shutterbug-lambda",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "shutterbug-lambda",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@sparticuz/chrome-aws-lambda": "^17.1.3",
         "puppeteer-core": "^17.1.3"
@@ -102,6 +102,7 @@
       "version": "17.1.3",
       "resolved": "https://registry.npmjs.org/@sparticuz/chrome-aws-lambda/-/chrome-aws-lambda-17.1.3.tgz",
       "integrity": "sha512-SeicVg+oVw04x7a0DqzSgzDK/DdBpVRql0jTC3bxfvrBGIt5oK2CgvP/oACuKIHNjrRZrY0oTww9/SsJ2o9ebg==",
+      "deprecated": "@sparticuz/chrome-aws-lambda is deprecated. Please migrate to @sparticuz/chromium",
       "dependencies": {
         "tar-fs": "^2.1.1"
       },
@@ -113,9 +114,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.8.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.0.tgz",
-      "integrity": "sha512-u+h43R6U8xXDt2vzUaVP3VwjjLyOJk6uEciZS8OSyziUQGOwmk+l+4drxcsDboHXwyTaqS1INebghmWMRxq3LA==",
+      "version": "18.8.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
+      "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==",
       "optional": true
     },
     "node_modules/@types/yauzl": {
@@ -363,9 +364,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1227.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1227.0.tgz",
-      "integrity": "sha512-L6vnopVXVXKEqi0R4i54F6xSemczd/aRy4UscqnfpyvNYr9yLL3jVApFo7OX8hxompe/tgxdQFXvMiNzhkSrwQ==",
+      "version": "2.1230.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1230.0.tgz",
+      "integrity": "sha512-7Y260dvzr7b8/lZhg6A7h5WyHvfCgdFL0NiBgCuT3/xlw9rvq9b08JNYErEpaJSmo+A5hW35n6wtzii4/FUSTA==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -1289,9 +1290,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001414",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001414.tgz",
-      "integrity": "sha512-t55jfSaWjCdocnFdKQoO+d2ct9C59UZg4dY3OnUlSZ447r8pUtIKdp0hpAzrGFultmTC+Us+KpKi4GZl/LXlFg==",
+      "version": "1.0.30001416",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001416.tgz",
+      "integrity": "sha512-06wzzdAkCPZO+Qm4e/eNghZBDfVNDsCgw33T27OwBH9unE9S478OYw//Q2L7Npf/zBzs7rjZOszIFQkwQKAEqA==",
       "dev": true,
       "funding": [
         {
@@ -1704,9 +1705,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.270",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.270.tgz",
-      "integrity": "sha512-KNhIzgLiJmDDC444dj9vEOpZEgsV96ult9Iff98Vanumn+ShJHd5se8aX6KeVxdc0YQeqdrezBZv89rleDbvSg==",
+      "version": "1.4.274",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.274.tgz",
+      "integrity": "sha512-Fgn7JZQzq85I81FpKUNxVLAzoghy8JZJ4NIue+YfUYBbu1AkpgzFvNwzF/ZNZH9ElkmJD0TSWu1F2gTpw/zZlg==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -6985,9 +6986,9 @@
       }
     },
     "@types/node": {
-      "version": "18.8.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.0.tgz",
-      "integrity": "sha512-u+h43R6U8xXDt2vzUaVP3VwjjLyOJk6uEciZS8OSyziUQGOwmk+l+4drxcsDboHXwyTaqS1INebghmWMRxq3LA==",
+      "version": "18.8.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
+      "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==",
       "optional": true
     },
     "@types/yauzl": {
@@ -7166,9 +7167,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.1227.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1227.0.tgz",
-      "integrity": "sha512-L6vnopVXVXKEqi0R4i54F6xSemczd/aRy4UscqnfpyvNYr9yLL3jVApFo7OX8hxompe/tgxdQFXvMiNzhkSrwQ==",
+      "version": "2.1230.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1230.0.tgz",
+      "integrity": "sha512-7Y260dvzr7b8/lZhg6A7h5WyHvfCgdFL0NiBgCuT3/xlw9rvq9b08JNYErEpaJSmo+A5hW35n6wtzii4/FUSTA==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -8022,9 +8023,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001414",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001414.tgz",
-      "integrity": "sha512-t55jfSaWjCdocnFdKQoO+d2ct9C59UZg4dY3OnUlSZ447r8pUtIKdp0hpAzrGFultmTC+Us+KpKi4GZl/LXlFg==",
+      "version": "1.0.30001416",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001416.tgz",
+      "integrity": "sha512-06wzzdAkCPZO+Qm4e/eNghZBDfVNDsCgw33T27OwBH9unE9S478OYw//Q2L7Npf/zBzs7rjZOszIFQkwQKAEqA==",
       "dev": true
     },
     "chalk": {
@@ -8361,9 +8362,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.270",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.270.tgz",
-      "integrity": "sha512-KNhIzgLiJmDDC444dj9vEOpZEgsV96ult9Iff98Vanumn+ShJHd5se8aX6KeVxdc0YQeqdrezBZv89rleDbvSg==",
+      "version": "1.4.274",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.274.tgz",
+      "integrity": "sha512-Fgn7JZQzq85I81FpKUNxVLAzoghy8JZJ4NIue+YfUYBbu1AkpgzFvNwzF/ZNZH9ElkmJD0TSWu1F2gTpw/zZlg==",
       "dev": true
     },
     "emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "babel": "rm -rf dist && mkdir dist && ./node_modules/.bin/babel src --out-dir dist",
     "test": "node src/test.js",
     "server": "node src/test-server.js",
-    "server-headless": "HEADLESS=true node src/test-server.js",
+    "server-non-headless": "HEADLESS=false node src/test-server.js",
     "lint": "standard --fix src/**/*.js"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -103,13 +103,15 @@ exports.handler = async (event, context, callback) => {
 
 exports.run = async (path, inputJson) => {
   if (path === '/make-snapshot') {
-    console.time("make-snapshot")
+    console.time("complete request processing")
     let attempt = 0
     let snapshotUrl = null
     let error = null
     while (!snapshotUrl && attempt < MAX_ATTEMPTS) {
       attempt += 1
+      console.time("browser setup")
       const browser = await getBrowser()
+      console.timeEnd("browser setup")
       try {
         console.log('makeSnapshot, attempt:', attempt)
         snapshotUrl = await makeSnapshot(getOptions(inputJson), browser)
@@ -122,7 +124,7 @@ exports.run = async (path, inputJson) => {
       }
     }
 
-    console.timeEnd("make-snapshot")
+    console.timeEnd("complete request processing")
     if (snapshotUrl) {
       return getResponse(snapshotUrl)
     } else {

--- a/src/lib/make-snapshot.js
+++ b/src/lib/make-snapshot.js
@@ -30,6 +30,8 @@ module.exports = async function makesSnapshot (options, browser) {
   // in time, but that is OK.
   uploadToS3(htmlKey, content, 'text/html')
 
+  console.time("page setup and loading")
+
   const page = await browser.newPage()
   await page.setViewport({ width: options.width, height: options.height })
 
@@ -53,5 +55,8 @@ module.exports = async function makesSnapshot (options, browser) {
   console.log('snapshot taken')
   await page.close()
   console.log('page closed')
+
+  console.timeEnd("page setup and loading")
+
   return uploadToS3(screenshotKey, buffer, 'image/png')
 }

--- a/src/lib/upload-to-s3.js
+++ b/src/lib/upload-to-s3.js
@@ -6,6 +6,7 @@ const s3 = new AWS.S3()
 module.exports = function uploadToS3 (key, buffer, contentType) {
   return new Promise((resolve, reject) => {
     console.log('uploading', key, 'to S3 bucket...')
+    console.time("upload to s3")
     s3.upload({ Bucket: bucket, Key: key,
       ContentType: contentType, Body: buffer }, function (err, data) {
       if (err) {
@@ -13,6 +14,7 @@ module.exports = function uploadToS3 (key, buffer, contentType) {
       } else {
         resolve(data.Location)
       }
+      console.timeEnd("upload to s3")
     })
   })
 }

--- a/src/test-server.js
+++ b/src/test-server.js
@@ -1,18 +1,10 @@
 const http = require('http')
-const puppeteer = require('puppeteer')
 const index = require('./index')
 
 const port = 4000
 
 async function runLambdaFunc (path, postBody) {
-  const getBrowser = async () => {
-    const headless = process.env.HEADLESS
-    return puppeteer.launch({
-      headless,
-      slowMo: headless ? false : 500 // slow down execution in non-headless mode
-    })
-  }
-  return index.run(path, postBody, getBrowser)
+  return index.run(path, postBody)
 }
 
 const requestHandler = (request, response) => {

--- a/src/test.js
+++ b/src/test.js
@@ -1,5 +1,4 @@
-const index = require('./index')
-const puppeteer = require('puppeteer');
+const index = require('./index');
 
 (async () => {
   const testEvent = {
@@ -9,13 +8,7 @@ const puppeteer = require('puppeteer');
     "height": "200",
     "base_url": "http://concord.org"
   }
-  const getBrowser = async () => {
-    return puppeteer.launch({
-      slowMo: 500,
-      headless: false
-    })
-  }
-  await index.run('/make-snapshot', testEvent, getBrowser)
+  await index.run('/make-snapshot', testEvent)
     .then((result) => console.log(result))
     .catch((err) => console.error(err))
 })()


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/183471233

This PR is an attempt to improve the Shutterbug server response. Generally, I think that the main reason of Labbook slowness is its own questionable implementation (it issues lots of Shutterbug requests -> each time user makes a smallest update to the drawing, so requests can pile up. There's no throttling, and requests are not canceled). But I looked at the Shutterbug response time anyway, as I was in the right context.

PR changes:
1. Unifies how Chrome is launched locally and on AWS Lambda (always using chrome-aws-lambda package, as it works locally too).
2. Adds more metrics to logs so they can be inspected in Cloudwatch.
3. Most importantly: runs the browser in headless mode in AWS Lambda and it doesn't close the browser after each request. Instead, it tries to reuse it for the next request(s). 
4. I've also added more memory / CPU in AWS configuration.

3 is a bit risky, but it can save quite a lot of time (1-2 seconds per request). For the very basic "Hello World" example dropped from 2.5-3s to 1-1.3s per request. In my first attempt, I could see that the connection to the browser was lost sometimes, but now it should be handled. I issued lots of requests using the test site and I think that errors are handled correctly now. The code will try to restart the browser if necessary. So once in a while, one request can be slower (also, the first one is a slow one with Lambda starting itself and then the browser). But I think performance inside Labbook should be much better. I'll keep an eye on the error rate in AWS metrics when this approach reaches production.

It's possible to test it using demo page with `?shutterbugUrl=https://dgjr6g3z30.execute-api.us-east-1.amazonaws.com/staging` param. 

For example this will talk to an updated server:
https://concord-consortium.github.io/shutterbug.js/demo/simple-example.html?shutterbugUrl=https://dgjr6g3z30.execute-api.us-east-1.amazonaws.com/staging

This is talking to production:
https://concord-consortium.github.io/shutterbug.js/demo/simple-example.html

You can open the Network tab in Chrome and look for "make-snapshot" requests. Staging should be around 1.3s after warmup and production around 3.8s.