### PR TITLE
Improve s3 upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist
 package.zip
+package-*
 .local-chromium
 local-chromium.tar.gz
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "shutterbug-lambda",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "shutterbug-lambda",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@sparticuz/chrome-aws-lambda": "^17.1.3",
         "puppeteer-core": "^17.1.3"
       },
       "devDependencies": {
-        "aws-sdk": "^2.1227.0",
+        "aws-sdk": "^2.1232.0",
         "babel-cli": "^6.26.0",
         "babel-preset-env": "^1.7.0",
         "puppeteer": "^17.1.3",
@@ -473,9 +473,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1230.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1230.0.tgz",
-      "integrity": "sha512-7Y260dvzr7b8/lZhg6A7h5WyHvfCgdFL0NiBgCuT3/xlw9rvq9b08JNYErEpaJSmo+A5hW35n6wtzii4/FUSTA==",
+      "version": "2.1232.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1232.0.tgz",
+      "integrity": "sha512-hpWsIdfyIK8uVWzCAHAqa3V2P/pkDy5SHy2QytpY/HylT2TnMT9NNd5hblfpvttfoIKoArnYQzVKtC20H/+yUg==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -7114,9 +7114,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.1230.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1230.0.tgz",
-      "integrity": "sha512-7Y260dvzr7b8/lZhg6A7h5WyHvfCgdFL0NiBgCuT3/xlw9rvq9b08JNYErEpaJSmo+A5hW35n6wtzii4/FUSTA==",
+      "version": "2.1232.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1232.0.tgz",
+      "integrity": "sha512-hpWsIdfyIK8uVWzCAHAqa3V2P/pkDy5SHy2QytpY/HylT2TnMT9NNd5hblfpvttfoIKoArnYQzVKtC20H/+yUg==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shutterbug-lambda",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "puppeteer-core": "^17.1.3"
   },
   "devDependencies": {
-    "aws-sdk": "^2.1227.0",
+    "aws-sdk": "^2.1232.0",
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "puppeteer": "^17.1.3",

--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,8 @@ exports.handler = async (event, context, callback) => {
       body: JSON.stringify(result)
     })
   } catch (err) {
-    callback(new Error(err))
+    console.error('snapshot request failed:', err)
+    callback(err)
   }
 }
 

--- a/src/lib/make-snapshot.js
+++ b/src/lib/make-snapshot.js
@@ -25,10 +25,9 @@ module.exports = async function makesSnapshot (options, browser) {
   const screenshotKey = baseKey + '.png'
   const htmlKey = baseKey + '.html'
   const content = getHtml(options.html, options.css, options.baseUrl)
+
   // this helps with debugging issues with snapshots.
-  // it is not waited for, so in some cases it might not complete the upload
-  // in time, but that is OK.
-  uploadToS3(htmlKey, content, 'text/html')
+  await uploadToS3(htmlKey, content, 'text/html')
 
   console.time('page setup and loading')
 

--- a/src/lib/upload-to-s3.js
+++ b/src/lib/upload-to-s3.js
@@ -1,24 +1,51 @@
 const AWS = require('aws-sdk')
 
 const bucket = 'ccshutterbug'
-const s3 = new AWS.S3()
+let s3 = new AWS.S3()
 
-module.exports = function uploadToS3 (key, buffer, contentType) {
-  return new Promise((resolve, reject) => {
-    console.log('uploading', key, 'to S3 bucket...')
-    console.time('upload to s3')
-    s3.upload({
-      Bucket: bucket,
-      Key: key,
-      ContentType: contentType,
-      Body: buffer
-    }, function (err, data) {
-      if (err) {
-        reject(err)
-      } else {
-        resolve(data.Location)
-      }
-      console.timeEnd('upload to s3')
-    })
-  })
+
+// This might see overcomplicated, but  S3 upload seems to randomly get stack once in a while.
+// See: https://www.pivotaltracker.com/story/show/183543485
+const MAX_ATTEMPTS = 5
+const BASE_TIMEOUT = 5000 // usually S3 upload takes around ~100ms, so that's plenty of time
+
+module.exports = async function uploadToS3 (key, buffer, contentType) {
+  console.log('uploading', key, 'to S3 bucket...')
+  console.time('upload to s3')
+
+  let attempt = 0;
+  let objectLocation = null
+  let error
+
+  while (!objectLocation && attempt < MAX_ATTEMPTS) {
+    try {
+      attempt += 1
+      console.log(`s3 upload attempt: ${attempt}`)
+      const managedUpload = s3.upload({
+        Bucket: bucket,
+        Key: key,
+        ContentType: contentType,
+        Body: buffer
+      })
+
+      const timeoutId = setTimeout(function() {
+        managedUpload.abort()
+      }, BASE_TIMEOUT * attempt)
+
+      const uploadResult = await managedUpload.promise()
+      objectLocation = uploadResult.Location
+
+      clearTimeout(timeoutId)
+    } catch (err) {
+      error = err
+    }
+  }
+
+  console.timeEnd('upload to s3')
+
+  if (objectLocation) {
+    return objectLocation
+  } else {
+    throw error
+  }
 }

--- a/src/lib/upload-to-s3.js
+++ b/src/lib/upload-to-s3.js
@@ -6,7 +6,7 @@ const s3 = new AWS.S3()
 // This might seem overcomplicated, but  S3 upload seems to randomly get stuck once in a while.
 // See: https://www.pivotaltracker.com/story/show/183543485
 const MAX_ATTEMPTS = 5
-const BASE_TIMEOUT = 5000 // usually S3 upload takes around ~100ms, so that's plenty of time
+const BASE_TIMEOUT = 3500 // usually S3 upload takes around ~100ms, so that's plenty of time
 
 module.exports = async function uploadToS3 (key, buffer, contentType) {
   console.log('uploading', key, 'to S3 bucket...')
@@ -29,7 +29,7 @@ module.exports = async function uploadToS3 (key, buffer, contentType) {
 
       const timeoutId = setTimeout(function () {
         managedUpload.abort()
-      }, BASE_TIMEOUT * attempt)
+      }, BASE_TIMEOUT * Math.sqrt(attempt))
 
       const uploadResult = await managedUpload.promise()
       objectLocation = uploadResult.Location

--- a/src/lib/upload-to-s3.js
+++ b/src/lib/upload-to-s3.js
@@ -3,7 +3,7 @@ const AWS = require('aws-sdk')
 const bucket = 'ccshutterbug'
 const s3 = new AWS.S3()
 
-// This might see overcomplicated, but  S3 upload seems to randomly get stack once in a while.
+// This might seem overcomplicated, but  S3 upload seems to randomly get stuck once in a while.
 // See: https://www.pivotaltracker.com/story/show/183543485
 const MAX_ATTEMPTS = 5
 const BASE_TIMEOUT = 5000 // usually S3 upload takes around ~100ms, so that's plenty of time

--- a/src/lib/upload-to-s3.js
+++ b/src/lib/upload-to-s3.js
@@ -1,8 +1,7 @@
 const AWS = require('aws-sdk')
 
 const bucket = 'ccshutterbug'
-let s3 = new AWS.S3()
-
+const s3 = new AWS.S3()
 
 // This might see overcomplicated, but  S3 upload seems to randomly get stack once in a while.
 // See: https://www.pivotaltracker.com/story/show/183543485
@@ -13,7 +12,7 @@ module.exports = async function uploadToS3 (key, buffer, contentType) {
   console.log('uploading', key, 'to S3 bucket...')
   console.time('upload to s3')
 
-  let attempt = 0;
+  let attempt = 0
   let objectLocation = null
   let error
 
@@ -28,7 +27,7 @@ module.exports = async function uploadToS3 (key, buffer, contentType) {
         Body: buffer
       })
 
-      const timeoutId = setTimeout(function() {
+      const timeoutId = setTimeout(function () {
         managedUpload.abort()
       }, BASE_TIMEOUT * attempt)
 

--- a/src/test-server.js
+++ b/src/test-server.js
@@ -27,6 +27,9 @@ const requestHandler = (request, response) => {
         .catch(err => {
           console.error('Request failed')
           console.error(err)
+          response.setHeader('Access-Control-Allow-Origin', '*')
+          response.setHeader('Content-Type', 'application/json')
+          response.statusCode = 500
           response.end(JSON.stringify({
             error: err
           }))


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/183543485

I've noticed that each time the new Shutterbug Lambda timed out, it happened during the final upload of the image to S3. See the screenshot in the comment. This can be handled by setting some explicit time for the upload to finish and trying again if it didn't work.

<img width="844" alt="timeout" src="https://user-images.githubusercontent.com/767857/195861544-44917095-24cc-4feb-8917-781e9e6b0794.png">
