### PR TITLE
Support CloudFormation stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Shutterbug AWS Lambda
 
 ## Production:
-https://fh1fzvhx93.execute-api.us-east-1.amazonaws.com/production/make-snapshot
+https://api.concord.org/shutterbug-production
 
 ## Staging:
-https://dgjr6g3z30.execute-api.us-east-1.amazonaws.com/staging/make-snapshot
+https://api.concord.org/shutterbug-staging
 
 ## Test:
 
-- `curl --data '{"content":"<p>Hello world!</p>","css":"<style>p { color: red; margin: 70px; }</style>","width":"400","height":"200","base_url":"http://concord.org"}' https://fh1fzvhx93.execute-api.us-east-1.amazonaws.com/production/make-snapshot`
-- `curl --data '{"url":"http://concord.org","width":1000,"height":800}' https://fh1fzvhx93.execute-api.us-east-1.amazonaws.com/production/make-snapshot`
+- `curl --data '{"content":"<p>Hello world!</p>","css":"<style>p { color: red; margin: 70px; }</style>","width":"400","height":"200","base_url":"http://concord.org"}' https://api.concord.org/shutterbug-production`
+- `curl --data '{"url":"http://concord.org","width":1000,"height":800}' https://api.concord.org/shutterbug-production`
 
 ## Basic test
 
@@ -24,24 +24,17 @@ Check https://github.com/concord-consortium/shutterbug.js library and its demo p
 
 ## Packaging & Deploy
 
-### Build Lambda package.zip
+Shutterbug is deployed using CloudFormation template. All the changes in configuration should be done there.
+You can find Shutterbug template in the dedicated repository: https://github.com/concord-consortium/cloud-formation
 
-Note that the archived Shutterbug Lambda code is slightly bigger than 50MB, so it's impossible to upload the code using
-AWS CLI tools or directly in the AWS Lambda console. The archive needs to be uploaded to S3 first.
+### Deploy new Lambda code
 
 - Run `npm run package` to create a `package.zip` archive
 - Rename it to `package-v<VERSION>.zip` and upload to [concord-devops/shutterbug-lambda](https://s3.console.aws.amazon.com/s3/buckets/concord-devops?region=us-east-1&prefix=shutterbug-lambda/) S3 bucket
-- Open [Shutterbug AWS Lambda console](https://us-east-1.console.aws.amazon.com/lambda/home?region=us-east-1#/functions/shutterbug?tab=code)
-  and click "Upload from" -> "Amazon S3 location". Then, provide an URL to the ZIP archive uploaded in a previous step and click "Save".
-
-### AWS Lambda configuration
-
-AWS Lambda's memory needs to be set to at least 384 MB, but the more memory, the better the performance of any operations.
-
-```
-512MB -> goto(youtube): 6.481s
-1536MB(Max) -> goto(youtube): 2.154s
-```
+- Open [Shutterbug AWS CloudFormation](https://us-east-1.console.aws.amazon.com/cloudformation)
+  and look for "shutterbug" or "shutterbug-staging" stack
+- Open production or staging stack, click "Update" button, and provide name of the newly uploaded Zip archive in the stack parameters
+- Start the stack update and wait for it to finish (it shouldn't take long)
 
 ## Update Headless-Chrome
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shutterbug-lambda",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "",
   "repository": {
     "type": "git",

--- a/src/test.js
+++ b/src/test.js
@@ -8,7 +8,7 @@ const index = require('./index');
     "height": "200",
     "base_url": "http://concord.org"
   }
-  await index.run('/make-snapshot', testEvent)
+  await index.run('/', testEvent)
     .then((result) => console.log(result))
     .catch((err) => console.error(err))
 })()


### PR DESCRIPTION
#183512066

To support Shutterbug created by CloudFormation template, I had to drop `make-snapshot` path. Now requests will go to the root path. Honestly, I couldn't easily find how to configure things to use /make-snapshot in CloudFront, but we didn't use any other path anyway so I don't think it's a problem. I've added more CORS headers too.

I've also updated readme - API URLs (they're nicer now) and the deployment method.